### PR TITLE
优化UI日志输出并调整窗口布局

### DIFF
--- a/main.py
+++ b/main.py
@@ -10,6 +10,7 @@ import tkinter as tk
 from tkinter import filedialog, messagebox, ttk
 import threading
 import re
+from datetime import datetime
 
 # 添加获取应用程序路径的函数
 def get_application_path():
@@ -76,9 +77,11 @@ def update_makefiles_with_correct_paths(callback=None):
     """
     # 用于记录和显示信息的帮助函数
     def show_message(message, is_error=False):
-        print(message)
+        timestamp = datetime.now().strftime("%H:%M:%S")
+        full_msg = f"[{timestamp}] {message}"
+        print(full_msg)
         if callback:
-            callback(message, is_error)
+            callback(full_msg, is_error)
     
     # 使用新的应用程序路径获取函数
     script_dir = get_application_path()
@@ -137,7 +140,7 @@ def update_makefiles_with_correct_paths(callback=None):
                     used_encoding = encoding
                     show_message("Successfully read file with {} encoding".format(encoding))
                     break
-                except UniLOC_COMPILEDeLOC_COMPILEError:
+                except UnicodeDecodeError:
                     show_message("Cannot read file with {} encoding, trying next...".format(encoding))
                     continue
             

--- a/vcu_compiler_ui.py
+++ b/vcu_compiler_ui.py
@@ -6,7 +6,8 @@ import sys
 import subprocess
 import shutil
 import tkinter as tk
-from tkinter import filedialog, messagebox, ttk
+from tkinter import filedialog, messagebox, ttk, scrolledtext
+from datetime import datetime
 import threading
 
 # 添加获取应用程序路径的函数
@@ -42,7 +43,8 @@ class VcuCompilerUI:
     def __init__(self, root, update_path_function=None, mvcu_path=None, svcu_path=None):
         self.root = root
         self.root.title("VCU编译器")
-        self.root.geometry("600x550")  # 增加窗口高度以容纳路径显示
+        self.root.geometry("700x600")  # 调整默认窗口尺寸
+        self.root.minsize(600, 500)
         self.root.resizable(True, True)
         
         # 保存路径更新函数
@@ -123,12 +125,10 @@ class VcuCompilerUI:
         log_frame = ttk.LabelFrame(main_frame, text="操作日志", padding="5")
         log_frame.pack(fill=tk.BOTH, expand=True, pady=10)
         
-        self.log_text = tk.Text(log_frame, wrap=tk.WORD, width=70, height=15)
-        self.log_text.pack(side=tk.LEFT, fill=tk.BOTH, expand=True)
-        
-        scrollbar = ttk.Scrollbar(log_frame, orient=tk.VERTICAL, command=self.log_text.yview)
-        scrollbar.pack(side=tk.RIGHT, fill=tk.Y)
-        self.log_text.config(yscrollcommand=scrollbar.set)
+        self.log_text = scrolledtext.ScrolledText(
+            log_frame, wrap=tk.WORD, width=70, height=15, font=("Consolas", 9)
+        )
+        self.log_text.pack(fill=tk.BOTH, expand=True)
         
         # 底部按钮区域
         btn_frame = ttk.Frame(main_frame, padding="5")
@@ -158,13 +158,19 @@ class VcuCompilerUI:
     
     def log(self, message, is_error=False):
         """向日志文本框添加消息"""
-        tag = "error" if is_error else None
-        
-        # 配置错误标签为红色
-        if is_error and "error" not in self.log_text.tag_names():
+        tag = "error" if is_error else "info"
+
+        if "info" not in self.log_text.tag_names():
+            self.log_text.tag_configure("info", foreground="black")
+        if "error" not in self.log_text.tag_names():
             self.log_text.tag_configure("error", foreground="red")
-        
-        self.log_text.insert(tk.END, message + "\n", tag)
+
+        if message.startswith("["):
+            formatted = message
+        else:
+            timestamp = datetime.now().strftime("%H:%M:%S")
+            formatted = f"[{timestamp}] {message}"
+        self.log_text.insert(tk.END, formatted + "\n", tag)
         self.log_text.see(tk.END)  # 滚动到最新行
     
     def update_compiler_paths(self):


### PR DESCRIPTION
## 更新内容
- UI 窗口尺寸调整并设置最小大小，日志区域使用 `ScrolledText`
- 日志记录及 `main.py` 的输出信息增加时间戳
- 修正文件末尾缺少换行的问题

## 测试
- `python -m py_compile main.py vcu_compiler_ui.py` 通过