### PR TITLE
实现复制归档并保留原始文件

### DIFF
--- a/main.py
+++ b/main.py
@@ -12,6 +12,20 @@ import threading
 import re
 from datetime import datetime
 
+# 输出结果归档函数
+def archive_output_files(output_dir):
+    """在输出目录下创建带时间戳的out文件夹，并复制 .s19 和 .lze 文件"""
+    timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
+    dest_dir = os.path.join(output_dir, f"out_{timestamp}")
+    os.makedirs(dest_dir, exist_ok=True)
+
+    for name in os.listdir(output_dir):
+        if name.lower().endswith((".s19", ".lze")):
+            src = os.path.join(output_dir, name)
+            shutil.copy2(src, os.path.join(dest_dir, name))
+
+    return dest_dir
+
 # 添加获取应用程序路径的函数
 def get_application_path():
     """获取应用程序的实际路径，适用于打包后的EXE文件"""
@@ -417,18 +431,19 @@ def process_in_console_mode(source_path):
             subprocess.Popen(["cmd", "/c", "start", "", msys_bat_path])
             print("MSYS已启动")
             
-            # 编译完成后，打开对应的输出文件夹
+            # 编译完成后，归档并打开对应的输出文件夹
             if vcu_type == "m":
                 output_dir = os.path.join(vcu_project_dir, "dev_kernel_mvcu", "build", "out")
-                if os.path.exists(output_dir):
-                    print(f"打开MVCU输出文件夹: {output_dir}")
-                    os.startfile(output_dir)
             elif vcu_type == "s":
                 output_dir = os.path.join(vcu_project_dir, "dev_kernel_svcu", "build", "out")
-                if os.path.exists(output_dir):
-                    print(f"打开SVCU输出文件夹: {output_dir}")
-                    os.startfile(output_dir)
-            
+            else:
+                output_dir = None
+
+            if output_dir and os.path.exists(output_dir):
+                archived_dir = archive_output_files(output_dir)
+                print(f"打开输出文件夹: {archived_dir}")
+                os.startfile(archived_dir)
+
             return True
         else:
             print(f"错误: 找不到MSYS批处理文件: {msys_bat_path}")

--- a/vcu_compiler_ui.py
+++ b/vcu_compiler_ui.py
@@ -26,13 +26,13 @@ def get_application_path():
 
 # 导入必要的模块
 try:
-    from main import check_modules_in_makefile
+    from main import check_modules_in_makefile, archive_output_files
 except ImportError:
     # 如果在当前目录找不到，尝试从同级目录导入
     LOC_COMPILE_dir = os.path.dirname(os.path.abspath(__file__))
     sys.path.append(LOC_COMPILE_dir)
     try:
-        from main import check_modules_in_makefile
+        from main import check_modules_in_makefile, archive_output_files
     except ImportError:
         # 避免循环导入
         check_modules_in_makefile = None
@@ -438,14 +438,15 @@ class VcuCompilerUI:
             if hasattr(self, 'vcu_type'):
                 if self.vcu_type == "m":
                     output_dir = os.path.join(script_dir, "VCU_compile - selftest", "dev_kernel_mvcu", "build", "out")
-                    if os.path.exists(output_dir):
-                        self.log(f"打开MVCU输出文件夹: {output_dir}")
-                        os.startfile(output_dir)
                 elif self.vcu_type == "s":
                     output_dir = os.path.join(script_dir, "VCU_compile - selftest", "dev_kernel_svcu", "build", "out")
-                    if os.path.exists(output_dir):
-                        self.log(f"打开SVCU输出文件夹: {output_dir}")
-                        os.startfile(output_dir)
+                else:
+                    output_dir = None
+
+                if output_dir and os.path.exists(output_dir):
+                    archived_dir = archive_output_files(output_dir)
+                    self.log(f"打开输出文件夹: {archived_dir}")
+                    os.startfile(archived_dir)
         else:
             self.status_var.set("编译失败")
             self.log("编译过程失败")


### PR DESCRIPTION
## Summary
- 调整 `archive_output_files`，在生成帶時間戳的子目錄時改為複製 `.s19` 與 `.lze` 文件，保留原目錄內容

## Testing
- `python3 -m py_compile main.py vcu_compiler_ui.py`