### PR TITLE
Fix packaged path handling

### DIFF
--- a/main.py
+++ b/main.py
@@ -152,9 +152,9 @@ def update_makefiles_with_correct_paths(callback=None):
     results = []  # 用于收集结果报告
     
     for makefile_path in makefile_paths:
+        # 预先判断makefile类型，确保在文件不存在的情况下也能记录
+        makefile_type = "MVCU" if "dev_kernel_mvcu" in makefile_path else "SVCU"
         if os.path.exists(makefile_path):
-            # 判断是哪个makefile
-            makefile_type = "MVCU" if "dev_kernel_mvcu" in makefile_path else "SVCU"
             show_message("Processing {} makefile...".format(makefile_type))
             
             # 尝试不同的编码

--- a/pack.py
+++ b/pack.py
@@ -11,7 +11,9 @@ from datetime import datetime
 
 def build_executable():
     """使用 PyInstaller 打包項目"""
-    project_root = os.path.dirname(os.path.abspath(__file__))
+    loc_dir = os.path.dirname(os.path.abspath(__file__))
+    # 与 main.py 中的 get_application_path() 保持一致，资源目录位于上级
+    project_root = os.path.dirname(loc_dir)
 
     timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
     exe_name = f"LOC_COMPILE_{timestamp}"
@@ -34,7 +36,7 @@ def build_executable():
         "--noconsole",
         "--name",
         exe_name,
-        os.path.join(project_root, "main.py"),
+        os.path.join(loc_dir, "main.py"),
     ]
 
     # 搜索可能需要打包的數據目錄

--- a/vcu_compiler_ui.py
+++ b/vcu_compiler_ui.py
@@ -353,6 +353,7 @@ class VcuCompilerUI:
         try:
             # 获取当前脚本所在目录
             script_dir = get_application_path()
+            resource_dir = get_resource_path()
             
             # 首先确保我们有最新的路径信息
             global update_msys_profile
@@ -452,7 +453,7 @@ class VcuCompilerUI:
                 self.log("无法进行模块检查，需要重新运行程序")
             
             # 启动MSYS
-            msys_bat_path = os.path.join(script_dir, "MSYS-1.0.10-selftest", "1.0", "msys.bat")
+            msys_bat_path = os.path.join(resource_dir, "MSYS-1.0.10-selftest", "1.0", "msys.bat")
             if os.path.exists(msys_bat_path):
                 self.log(f"启动MSYS: {msys_bat_path}")
                 subprocess.Popen(["cmd", "/c", "start", "", msys_bat_path])


### PR DESCRIPTION
## Summary
- align pack.py paths with `get_application_path`
- use resource path for launching MSYS in GUI mode

## Testing
- `python -m py_compile main.py vcu_compiler_ui.py pack.py`
